### PR TITLE
Fix minor documentation typos

### DIFF
--- a/lib/meilisearch/document.ex
+++ b/lib/meilisearch/document.ex
@@ -9,8 +9,8 @@ defmodule Meilisearch.Document do
   @type document_id() :: String.t() | integer()
 
   @doc """
-  List Documents of an Index of your Meilsiearch instance.
-  [meili doc](https://docs.meilisearch.com/reference/api/documents.html#get-documents)
+  List Documents of an Index of your Meilisearch instance.
+  [Meilisearch documentation](https://docs.meilisearch.com/reference/api/documents.html#get-documents)
 
   ## Examples
 
@@ -42,8 +42,8 @@ defmodule Meilisearch.Document do
   end
 
   @doc """
-  Get an Document of an Index in your Meilsiearch instance.
-  [meili doc](https://docs.meilisearch.com/reference/api/documents.html#get-one-document)
+  Get an Document of an Index in your Meilisearch instance.
+  [Meilisearch documentation](https://docs.meilisearch.com/reference/api/documents.html#get-one-document)
 
   ## Examples
 
@@ -66,8 +66,8 @@ defmodule Meilisearch.Document do
   end
 
   @doc """
-  Create or update a Documents into an Index in your Meilsiearch instance.
-  [meili doc](https://docs.meilisearch.com/reference/api/documents.html#add-or-replace-documents)
+  Create or update a Documents into an Index in your Meilisearch instance.
+  [Meilisearch documentation](https://docs.meilisearch.com/reference/api/documents.html#add-or-replace-documents)
 
   ## Examples
 
@@ -99,8 +99,8 @@ defmodule Meilisearch.Document do
   end
 
   @doc """
-  Create or update a Documents into an Index in your Meilsiearch instance.
-  [meili doc](https://docs.meilisearch.com/reference/api/documents.html#add-or-update-documents)
+  Create or update a Documents into an Index in your Meilisearch instance.
+  [Meilisearch documentation](https://docs.meilisearch.com/reference/api/documents.html#add-or-update-documents)
 
   ## Examples
 
@@ -132,8 +132,8 @@ defmodule Meilisearch.Document do
   end
 
   @doc """
-  Delete all Documents of an Index in your Meilsiearch instance.
-  [meili doc](https://docs.meilisearch.com/reference/api/documents.html#delete-all-documents)
+  Delete all Documents of an Index in your Meilisearch instance.
+  [Meilisearch documentation](https://docs.meilisearch.com/reference/api/documents.html#delete-all-documents)
 
   ## Examples
 
@@ -162,8 +162,8 @@ defmodule Meilisearch.Document do
   end
 
   @doc """
-  Delete one Documents of an Index in your Meilsiearch instance.
-  [meili doc](https://docs.meilisearch.com/reference/api/documents.html#delete-one-document)
+  Delete one Documents of an Index in your Meilisearch instance.
+  [Meilisearch documentation](https://docs.meilisearch.com/reference/api/documents.html#delete-one-document)
 
   ## Examples
 
@@ -192,8 +192,8 @@ defmodule Meilisearch.Document do
   end
 
   @doc """
-  Delete a batch of Documents of an Index in your Meilsiearch instance.
-  [meili doc](https://docs.meilisearch.com/reference/api/documents.html#delete-documents-by-batch)
+  Delete a batch of Documents of an Index in your Meilisearch instance.
+  [Meilisearch documentation](https://docs.meilisearch.com/reference/api/documents.html#delete-documents-by-batch)
 
   ## Examples
 

--- a/lib/meilisearch/dump.ex
+++ b/lib/meilisearch/dump.ex
@@ -5,8 +5,8 @@ defmodule Meilisearch.Dump do
   """
 
   @doc """
-  Trigger a dump creation in your Meilsiearch instance.
-  [meili doc](https://docs.meilisearch.com/reference/api/dump.html#create-a-dump)
+  Trigger a dump creation in your Meilisearch instance.
+  [Meilisearch documentation](https://docs.meilisearch.com/reference/api/dump.html#create-a-dump)
 
   ## Examples
 

--- a/lib/meilisearch/health.ex
+++ b/lib/meilisearch/health.ex
@@ -19,7 +19,7 @@ defmodule Meilisearch.Health do
 
   @doc """
   Get a response from the /health endpoint of Meilisearch.
-  [meili doc](https://docs.meilisearch.com/reference/api/health.html#get-health)
+  [Meilisearch documentation](https://docs.meilisearch.com/reference/api/health.html#get-health)
 
   ## Examples
 
@@ -40,7 +40,7 @@ defmodule Meilisearch.Health do
 
   @doc """
   Check the response from the /health endpoint of Meilisearch.
-  [meili doc](https://docs.meilisearch.com/reference/api/health.html#get-health)
+  [Meilisearch documentation](https://docs.meilisearch.com/reference/api/health.html#get-health)
 
   ## Examples
 

--- a/lib/meilisearch/index.ex
+++ b/lib/meilisearch/index.ex
@@ -23,8 +23,8 @@ defmodule Meilisearch.Index do
   end
 
   @doc """
-  List indexes of your Meilsiearch instance.
-  [meili doc](https://docs.meilisearch.com/reference/api/indexes.html#index-object)
+  List indexes of your Meilisearch instance.
+  [Meilisearch documentation](https://docs.meilisearch.com/reference/api/indexes.html#index-object)
 
   ## Examples
 
@@ -51,8 +51,8 @@ defmodule Meilisearch.Index do
   end
 
   @doc """
-  Get an Index of your Meilsiearch instance.
-  [meili doc](https://docs.meilisearch.com/reference/api/indexes.html#get-one-index)
+  Get an Index of your Meilisearch instance.
+  [Meilisearch documentation](https://docs.meilisearch.com/reference/api/indexes.html#get-one-index)
 
   ## Examples
 
@@ -78,8 +78,8 @@ defmodule Meilisearch.Index do
   end
 
   @doc """
-  Create a new Index in your Meilsiearch instance.
-  [meili doc](https://docs.meilisearch.com/reference/api/indexes.html#create-an-index)
+  Create a new Index in your Meilisearch instance.
+  [Meilisearch documentation](https://docs.meilisearch.com/reference/api/indexes.html#create-an-index)
 
   ## Examples
 
@@ -106,8 +106,8 @@ defmodule Meilisearch.Index do
   end
 
   @doc """
-  Update an existing Index in your Meilsiearch instance.
-  [meili doc](https://docs.meilisearch.com/reference/api/indexes.html#update-an-index)
+  Update an existing Index in your Meilisearch instance.
+  [Meilisearch documentation](https://docs.meilisearch.com/reference/api/indexes.html#update-an-index)
 
   ## Examples
 
@@ -136,8 +136,8 @@ defmodule Meilisearch.Index do
   end
 
   @doc """
-  Delete an existing Index in your Meilsiearch instance.
-  [meili doc](https://docs.meilisearch.com/reference/api/indexes.html#delete-an-index)
+  Delete an existing Index in your Meilisearch instance.
+  [Meilisearch documentation](https://docs.meilisearch.com/reference/api/indexes.html#delete-an-index)
 
   ## Examples
 
@@ -164,8 +164,8 @@ defmodule Meilisearch.Index do
   end
 
   @doc """
-  Create a new Index in your Meilsiearch instance.
-  [meili doc](https://docs.meilisearch.com/reference/api/indexes.html#create-an-index)
+  Create a new Index in your Meilisearch instance.
+  [Meilisearch documentation](https://docs.meilisearch.com/reference/api/indexes.html#create-an-index)
 
   ## Examples
 

--- a/lib/meilisearch/key.ex
+++ b/lib/meilisearch/key.ex
@@ -38,8 +38,8 @@ defmodule Meilisearch.Key do
   end
 
   @doc """
-  List keys of your Meilsiearch instance.
-  [meili doc](https://docs.meilisearch.com/reference/api/keys.html#get-all-keys)
+  List keys of your Meilisearch instance.
+  [Meilisearch documentation](https://docs.meilisearch.com/reference/api/keys.html#get-all-keys)
 
   ## Examples
 
@@ -71,8 +71,8 @@ defmodule Meilisearch.Key do
   end
 
   @doc """
-  Get a Key of your Meilsiearch instance.
-  [meili doc](https://docs.meilisearch.com/reference/api/keys.html#get-one-key)
+  Get a Key of your Meilisearch instance.
+  [Meilisearch documentation](https://docs.meilisearch.com/reference/api/keys.html#get-one-key)
 
   ## Examples
 
@@ -103,8 +103,8 @@ defmodule Meilisearch.Key do
   end
 
   @doc """
-  Create a new Key in your Meilsiearch instance.
-  [meili doc](https://docs.meilisearch.com/reference/api/keys.html#create-a-key)
+  Create a new Key in your Meilisearch instance.
+  [Meilisearch documentation](https://docs.meilisearch.com/reference/api/keys.html#create-a-key)
 
   ## Examples
 
@@ -142,8 +142,8 @@ defmodule Meilisearch.Key do
   end
 
   @doc """
-  Update an existing Key in your Meilsiearch instance.
-  [meili doc](https://docs.meilisearch.com/reference/api/keys.html#update-a-key)
+  Update an existing Key in your Meilisearch instance.
+  [Meilisearch documentation](https://docs.meilisearch.com/reference/api/keys.html#update-a-key)
 
   ## Examples
 
@@ -177,8 +177,8 @@ defmodule Meilisearch.Key do
   end
 
   @doc """
-  Delete an existing Index in your Meilsiearch instance.
-  [meili doc](https://docs.meilisearch.com/reference/api/indexes.html#delete-an-index)
+  Delete an existing Index in your Meilisearch instance.
+  [Meilisearch documentation](https://docs.meilisearch.com/reference/api/indexes.html#delete-an-index)
 
   ## Examples
 

--- a/lib/meilisearch/search.ex
+++ b/lib/meilisearch/search.ex
@@ -74,7 +74,7 @@ defmodule Meilisearch.Search do
 
   @doc """
   Search into your Meilisearch indexes using a POST request.
-  [meili doc](https://docs.meilisearch.com/reference/api/indexes.html#get-one-index)
+  [Meilisearch documentation](https://docs.meilisearch.com/reference/api/indexes.html#get-one-index)
 
   ## Examples
 

--- a/lib/meilisearch/settings.ex
+++ b/lib/meilisearch/settings.ex
@@ -35,8 +35,8 @@ defmodule Meilisearch.Settings do
   end
 
   @doc """
-  Get settings of an Index of your Meilsiearch instance.
-  [meili doc](https://docs.meilisearch.com/reference/api/settings.html#get-settings)
+  Get settings of an Index of your Meilisearch instance.
+  [Meilisearch documentation](https://docs.meilisearch.com/reference/api/settings.html#get-settings)
 
   ## Examples
 
@@ -64,8 +64,8 @@ defmodule Meilisearch.Settings do
   end
 
   @doc """
-  Update settings of an Index in your Meilsiearch instance.
-  [meili doc](https://docs.meilisearch.com/reference/api/settings.html#update-settings)
+  Update settings of an Index in your Meilisearch instance.
+  [Meilisearch documentation](https://docs.meilisearch.com/reference/api/settings.html#update-settings)
 
   ## Examples
 
@@ -94,8 +94,8 @@ defmodule Meilisearch.Settings do
   end
 
   @doc """
-  Reset settings of an Index in your Meilsiearch instance.
-  [meili doc](https://docs.meilisearch.com/reference/api/settings.html#reset-settings)
+  Reset settings of an Index in your Meilisearch instance.
+  [Meilisearch documentation](https://docs.meilisearch.com/reference/api/settings.html#reset-settings)
 
   ## Examples
 
@@ -125,8 +125,8 @@ defmodule Meilisearch.Settings do
 
   defmodule DisplayedAttributes do
     @doc """
-    Get displayed attributes settings of an Index of your Meilsiearch instance.
-    [meili doc](https://docs.meilisearch.com/reference/api/settings.html#get-displayed-attributes)
+    Get displayed attributes settings of an Index of your Meilisearch instance.
+    [Meilisearch documentation](https://docs.meilisearch.com/reference/api/settings.html#get-displayed-attributes)
 
     ## Examples
 
@@ -146,8 +146,8 @@ defmodule Meilisearch.Settings do
     end
 
     @doc """
-    Update displayed attributes settings of an Index of your Meilsiearch instance.
-    [meili doc](https://docs.meilisearch.com/reference/api/settings.html#update-displayed-attributes)
+    Update displayed attributes settings of an Index of your Meilisearch instance.
+    [Meilisearch documentation](https://docs.meilisearch.com/reference/api/settings.html#update-displayed-attributes)
 
     ## Examples
 
@@ -176,8 +176,8 @@ defmodule Meilisearch.Settings do
     end
 
     @doc """
-    Reset displayed attributes settings of an Index of your Meilsiearch instance.
-    [meili doc](https://docs.meilisearch.com/reference/api/settings.html#get-displayed-attributes)
+    Reset displayed attributes settings of an Index of your Meilisearch instance.
+    [Meilisearch documentation](https://docs.meilisearch.com/reference/api/settings.html#get-displayed-attributes)
 
     ## Examples
 
@@ -208,8 +208,8 @@ defmodule Meilisearch.Settings do
 
   defmodule SearchableAttributes do
     @doc """
-    Get searchable attributes settings of an Index of your Meilsiearch instance.
-    [meili doc](https://docs.meilisearch.com/reference/api/settings.html#get-searchable-attributes)
+    Get searchable attributes settings of an Index of your Meilisearch instance.
+    [Meilisearch documentation](https://docs.meilisearch.com/reference/api/settings.html#get-searchable-attributes)
 
     ## Examples
 
@@ -229,8 +229,8 @@ defmodule Meilisearch.Settings do
     end
 
     @doc """
-    Update searchable attributes settings of an Index of your Meilsiearch instance.
-    [meili doc](https://docs.meilisearch.com/reference/api/settings.html#update-searchable-attributes)
+    Update searchable attributes settings of an Index of your Meilisearch instance.
+    [Meilisearch documentation](https://docs.meilisearch.com/reference/api/settings.html#update-searchable-attributes)
 
     ## Examples
 
@@ -259,8 +259,8 @@ defmodule Meilisearch.Settings do
     end
 
     @doc """
-    Reset searchable attributes settings of an Index of your Meilsiearch instance.
-    [meili doc](https://docs.meilisearch.com/reference/api/settings.html#get-searchable-attributes)
+    Reset searchable attributes settings of an Index of your Meilisearch instance.
+    [Meilisearch documentation](https://docs.meilisearch.com/reference/api/settings.html#get-searchable-attributes)
 
     ## Examples
 
@@ -291,8 +291,8 @@ defmodule Meilisearch.Settings do
 
   defmodule FilterableAttributes do
     @doc """
-    Get filterable attributes settings of an Index of your Meilsiearch instance.
-    [meili doc](https://docs.meilisearch.com/reference/api/settings.html#get-filterable-attributes)
+    Get filterable attributes settings of an Index of your Meilisearch instance.
+    [Meilisearch documentation](https://docs.meilisearch.com/reference/api/settings.html#get-filterable-attributes)
 
     ## Examples
 
@@ -312,8 +312,8 @@ defmodule Meilisearch.Settings do
     end
 
     @doc """
-    Update filterable attributes settings of an Index of your Meilsiearch instance.
-    [meili doc](https://docs.meilisearch.com/reference/api/settings.html#update-filterable-attributes)
+    Update filterable attributes settings of an Index of your Meilisearch instance.
+    [Meilisearch documentation](https://docs.meilisearch.com/reference/api/settings.html#update-filterable-attributes)
 
     ## Examples
 
@@ -342,8 +342,8 @@ defmodule Meilisearch.Settings do
     end
 
     @doc """
-    Reset filterable attributes settings of an Index of your Meilsiearch instance.
-    [meili doc](https://docs.meilisearch.com/reference/api/settings.html#get-filterable-attributes)
+    Reset filterable attributes settings of an Index of your Meilisearch instance.
+    [Meilisearch documentation](https://docs.meilisearch.com/reference/api/settings.html#get-filterable-attributes)
 
     ## Examples
 
@@ -374,8 +374,8 @@ defmodule Meilisearch.Settings do
 
   defmodule SortableAttributes do
     @doc """
-    Get sortable attributes settings of an Index of your Meilsiearch instance.
-    [meili doc](https://docs.meilisearch.com/reference/api/settings.html#get-sortable-attributes)
+    Get sortable attributes settings of an Index of your Meilisearch instance.
+    [Meilisearch documentation](https://docs.meilisearch.com/reference/api/settings.html#get-sortable-attributes)
 
     ## Examples
 
@@ -395,8 +395,8 @@ defmodule Meilisearch.Settings do
     end
 
     @doc """
-    Update sortable attributes settings of an Index of your Meilsiearch instance.
-    [meili doc](https://docs.meilisearch.com/reference/api/settings.html#update-sortable-attributes)
+    Update sortable attributes settings of an Index of your Meilisearch instance.
+    [Meilisearch documentation](https://docs.meilisearch.com/reference/api/settings.html#update-sortable-attributes)
 
     ## Examples
 
@@ -425,8 +425,8 @@ defmodule Meilisearch.Settings do
     end
 
     @doc """
-    Reset sortable attributes settings of an Index of your Meilsiearch instance.
-    [meili doc](https://docs.meilisearch.com/reference/api/settings.html#get-sortable-attributes)
+    Reset sortable attributes settings of an Index of your Meilisearch instance.
+    [Meilisearch documentation](https://docs.meilisearch.com/reference/api/settings.html#get-sortable-attributes)
 
     ## Examples
 
@@ -457,8 +457,8 @@ defmodule Meilisearch.Settings do
 
   defmodule RankingRules do
     @doc """
-    Get ranking rules settings of an Index of your Meilsiearch instance.
-    [meili doc](https://docs.meilisearch.com/reference/api/settings.html#get-ranking-rules)
+    Get ranking rules settings of an Index of your Meilisearch instance.
+    [Meilisearch documentation](https://docs.meilisearch.com/reference/api/settings.html#get-ranking-rules)
 
     ## Examples
 
@@ -478,8 +478,8 @@ defmodule Meilisearch.Settings do
     end
 
     @doc """
-    Update ranking rules settings of an Index of your Meilsiearch instance.
-    [meili doc](https://docs.meilisearch.com/reference/api/settings.html#update-ranking-rules)
+    Update ranking rules settings of an Index of your Meilisearch instance.
+    [Meilisearch documentation](https://docs.meilisearch.com/reference/api/settings.html#update-ranking-rules)
 
     ## Examples
 
@@ -508,8 +508,8 @@ defmodule Meilisearch.Settings do
     end
 
     @doc """
-    Reset ranking rules settings of an Index of your Meilsiearch instance.
-    [meili doc](https://docs.meilisearch.com/reference/api/settings.html#get-ranking-rules)
+    Reset ranking rules settings of an Index of your Meilisearch instance.
+    [Meilisearch documentation](https://docs.meilisearch.com/reference/api/settings.html#get-ranking-rules)
 
     ## Examples
 
@@ -540,8 +540,8 @@ defmodule Meilisearch.Settings do
 
   defmodule StopWords do
     @doc """
-    Get stop words settings of an Index of your Meilsiearch instance.
-    [meili doc](https://docs.meilisearch.com/reference/api/settings.html#get-stop-words)
+    Get stop words settings of an Index of your Meilisearch instance.
+    [Meilisearch documentation](https://docs.meilisearch.com/reference/api/settings.html#get-stop-words)
 
     ## Examples
 
@@ -561,8 +561,8 @@ defmodule Meilisearch.Settings do
     end
 
     @doc """
-    Update stop words settings of an Index of your Meilsiearch instance.
-    [meili doc](https://docs.meilisearch.com/reference/api/settings.html#update-stop-words)
+    Update stop words settings of an Index of your Meilisearch instance.
+    [Meilisearch documentation](https://docs.meilisearch.com/reference/api/settings.html#update-stop-words)
 
     ## Examples
 
@@ -591,8 +591,8 @@ defmodule Meilisearch.Settings do
     end
 
     @doc """
-    Reset stop words settings of an Index of your Meilsiearch instance.
-    [meili doc](https://docs.meilisearch.com/reference/api/settings.html#get-stop-words)
+    Reset stop words settings of an Index of your Meilisearch instance.
+    [Meilisearch documentation](https://docs.meilisearch.com/reference/api/settings.html#get-stop-words)
 
     ## Examples
 
@@ -623,8 +623,8 @@ defmodule Meilisearch.Settings do
 
   defmodule Synonyms do
     @doc """
-    Get synonyms settings of an Index of your Meilsiearch instance.
-    [meili doc](https://docs.meilisearch.com/reference/api/settings.html#get-synonyms)
+    Get synonyms settings of an Index of your Meilisearch instance.
+    [Meilisearch documentation](https://docs.meilisearch.com/reference/api/settings.html#get-synonyms)
 
     ## Examples
 
@@ -648,8 +648,8 @@ defmodule Meilisearch.Settings do
     end
 
     @doc """
-    Update synonyms settings of an Index of your Meilsiearch instance.
-    [meili doc](https://docs.meilisearch.com/reference/api/settings.html#update-synonyms)
+    Update synonyms settings of an Index of your Meilisearch instance.
+    [Meilisearch documentation](https://docs.meilisearch.com/reference/api/settings.html#update-synonyms)
 
     ## Examples
 
@@ -682,8 +682,8 @@ defmodule Meilisearch.Settings do
     end
 
     @doc """
-    Reset synonyms settings of an Index of your Meilsiearch instance.
-    [meili doc](https://docs.meilisearch.com/reference/api/settings.html#get-synonyms)
+    Reset synonyms settings of an Index of your Meilisearch instance.
+    [Meilisearch documentation](https://docs.meilisearch.com/reference/api/settings.html#get-synonyms)
 
     ## Examples
 
@@ -714,8 +714,8 @@ defmodule Meilisearch.Settings do
 
   defmodule DistinctAttributes do
     @doc """
-    Get distinct attribute settings of an Index of your Meilsiearch instance.
-    [meili doc](https://docs.meilisearch.com/reference/api/settings.html#get-distinct-attribute)
+    Get distinct attribute settings of an Index of your Meilisearch instance.
+    [Meilisearch documentation](https://docs.meilisearch.com/reference/api/settings.html#get-distinct-attribute)
 
     ## Examples
 
@@ -735,8 +735,8 @@ defmodule Meilisearch.Settings do
     end
 
     @doc """
-    Update distinct attribute settings of an Index of your Meilsiearch instance.
-    [meili doc](https://docs.meilisearch.com/reference/api/settings.html#update-distinct-attribute)
+    Update distinct attribute settings of an Index of your Meilisearch instance.
+    [Meilisearch documentation](https://docs.meilisearch.com/reference/api/settings.html#update-distinct-attribute)
 
     ## Examples
 
@@ -768,8 +768,8 @@ defmodule Meilisearch.Settings do
     end
 
     @doc """
-    Reset distinct attribute settings of an Index of your Meilsiearch instance.
-    [meili doc](https://docs.meilisearch.com/reference/api/settings.html#get-distinct-attribute)
+    Reset distinct attribute settings of an Index of your Meilisearch instance.
+    [Meilisearch documentation](https://docs.meilisearch.com/reference/api/settings.html#get-distinct-attribute)
 
     ## Examples
 
@@ -816,8 +816,8 @@ defmodule Meilisearch.Settings do
     end
 
     @doc """
-    Get faceting settings of an Index of your Meilsiearch instance.
-    [meili doc](https://docs.meilisearch.com/reference/api/settings.html#get-faceting-settings)
+    Get faceting settings of an Index of your Meilisearch instance.
+    [Meilisearch documentation](https://docs.meilisearch.com/reference/api/settings.html#get-faceting-settings)
 
     ## Examples
 
@@ -840,8 +840,8 @@ defmodule Meilisearch.Settings do
     end
 
     @doc """
-    Update faceting settings of an Index of your Meilsiearch instance.
-    [meili doc](https://docs.meilisearch.com/reference/api/settings.html#update-faceting-settings)
+    Update faceting settings of an Index of your Meilisearch instance.
+    [Meilisearch documentation](https://docs.meilisearch.com/reference/api/settings.html#update-faceting-settings)
 
     ## Examples
 
@@ -870,8 +870,8 @@ defmodule Meilisearch.Settings do
     end
 
     @doc """
-    Reset faceting settings of an Index of your Meilsiearch instance.
-    [meili doc](https://docs.meilisearch.com/reference/api/settings.html#reset-faceting-settings)
+    Reset faceting settings of an Index of your Meilisearch instance.
+    [Meilisearch documentation](https://docs.meilisearch.com/reference/api/settings.html#reset-faceting-settings)
 
     ## Examples
 
@@ -918,8 +918,8 @@ defmodule Meilisearch.Settings do
     end
 
     @doc """
-    Get pagination settings of an Index of your Meilsiearch instance.
-    [meili doc](https://docs.meilisearch.com/reference/api/settings.html#get-pagination-settings)
+    Get pagination settings of an Index of your Meilisearch instance.
+    [Meilisearch documentation](https://docs.meilisearch.com/reference/api/settings.html#get-pagination-settings)
 
     ## Examples
 
@@ -942,8 +942,8 @@ defmodule Meilisearch.Settings do
     end
 
     @doc """
-    Update pagination settings of an Index of your Meilsiearch instance.
-    [meili doc](https://docs.meilisearch.com/reference/api/settings.html#update-pagination-settings)
+    Update pagination settings of an Index of your Meilisearch instance.
+    [Meilisearch documentation](https://docs.meilisearch.com/reference/api/settings.html#update-pagination-settings)
 
     ## Examples
 
@@ -972,8 +972,8 @@ defmodule Meilisearch.Settings do
     end
 
     @doc """
-    Reset pagination settings of an Index of your Meilsiearch instance.
-    [meili doc](https://docs.meilisearch.com/reference/api/settings.html#reset-pagination-settings)
+    Reset pagination settings of an Index of your Meilisearch instance.
+    [Meilisearch documentation](https://docs.meilisearch.com/reference/api/settings.html#reset-pagination-settings)
 
     ## Examples
 
@@ -1026,8 +1026,8 @@ defmodule Meilisearch.Settings do
     end
 
     @doc """
-    Get typo tolerance settings of an Index of your Meilsiearch instance.
-    [meili doc](https://docs.meilisearch.com/reference/api/settings.html#get-typo-tolerance-settings)
+    Get typo tolerance settings of an Index of your Meilisearch instance.
+    [Meilisearch documentation](https://docs.meilisearch.com/reference/api/settings.html#get-typo-tolerance-settings)
 
     ## Examples
 
@@ -1058,8 +1058,8 @@ defmodule Meilisearch.Settings do
     end
 
     @doc """
-    Update typo tolerance settings of an Index of your Meilsiearch instance.
-    [meili doc](https://docs.meilisearch.com/reference/api/settings.html#update-typo-tolerance-settings)
+    Update typo tolerance settings of an Index of your Meilisearch instance.
+    [Meilisearch documentation](https://docs.meilisearch.com/reference/api/settings.html#update-typo-tolerance-settings)
 
     ## Examples
 
@@ -1096,8 +1096,8 @@ defmodule Meilisearch.Settings do
     end
 
     @doc """
-    Reset typo tolerance settings of an Index of your Meilsiearch instance.
-    [meili doc](https://docs.meilisearch.com/reference/api/settings.html#reset-typo-tolerance-settings)
+    Reset typo tolerance settings of an Index of your Meilisearch instance.
+    [Meilisearch documentation](https://docs.meilisearch.com/reference/api/settings.html#reset-typo-tolerance-settings)
 
     ## Examples
 

--- a/lib/meilisearch/stats.ex
+++ b/lib/meilisearch/stats.ex
@@ -31,8 +31,8 @@ defmodule Meilisearch.Stats do
   end
 
   @doc """
-  Get stats about all indexes of your Meilsiearch instance.
-  [meili doc](https://docs.meilisearch.com/reference/api/stats.html#get-stats-of-all-indexes)
+  Get stats about all indexes of your Meilisearch instance.
+  [Meilisearch documentation](https://docs.meilisearch.com/reference/api/stats.html#get-stats-of-all-indexes)
 
   ## Examples
 
@@ -81,8 +81,8 @@ defmodule Meilisearch.Stats do
   end
 
   @doc """
-  Get stats about a specific index of your Meilsiearch instance.
-  [meili doc](https://docs.meilisearch.com/reference/api/stats.html#get-stats-of-an-index)
+  Get stats about a specific index of your Meilisearch instance.
+  [Meilisearch documentation](https://docs.meilisearch.com/reference/api/stats.html#get-stats-of-an-index)
 
   ## Examples
 

--- a/lib/meilisearch/task.ex
+++ b/lib/meilisearch/task.ex
@@ -69,8 +69,8 @@ defmodule Meilisearch.Task do
   end
 
   @doc """
-  List tasks of your Meilsiearch instance.
-  [meili doc](https://docs.meilisearch.com/reference/api/tasks.html#get-tasks)
+  List tasks of your Meilisearch instance.
+  [Meilisearch documentation](https://docs.meilisearch.com/reference/api/tasks.html#get-tasks)
 
   ## Examples
 
@@ -112,8 +112,8 @@ defmodule Meilisearch.Task do
   end
 
   @doc """
-  Get an Task of your Meilsiearch instance.
-  [meili doc](https://docs.meilisearch.com/reference/api/tasks.html#get-one-task)
+  Get an Task of your Meilisearch instance.
+  [Meilisearch documentation](https://docs.meilisearch.com/reference/api/tasks.html#get-one-task)
 
   ## Examples
 
@@ -155,8 +155,8 @@ defmodule Meilisearch.Task do
   end
 
   @doc """
-  Cancel tasks of your Meilsiearch instance.
-  [meili doc](https://docs.meilisearch.com/reference/api/tasks.html#cancel-tasks)
+  Cancel tasks of your Meilisearch instance.
+  [Meilisearch documentation](https://docs.meilisearch.com/reference/api/tasks.html#cancel-tasks)
 
   ## Examples
 
@@ -195,8 +195,8 @@ defmodule Meilisearch.Task do
   end
 
   @doc """
-  Delete tasks of your Meilsiearch instance.
-  [meili doc](https://docs.meilisearch.com/reference/api/tasks.html#delete-tasks)
+  Delete tasks of your Meilisearch instance.
+  [Meilisearch documentation](https://docs.meilisearch.com/reference/api/tasks.html#delete-tasks)
 
   ## Examples
 

--- a/lib/meilisearch/version.ex
+++ b/lib/meilisearch/version.ex
@@ -21,7 +21,7 @@ defmodule Meilisearch.Version do
 
   @doc """
   Get a response from the /version endpoint of Meilisearch.
-  [meili doc](https://docs.meilisearch.com/reference/api/version.html#get-version-of-meilisearch)
+  [Meilisearch documentation](https://docs.meilisearch.com/reference/api/version.html#get-version-of-meilisearch)
 
   ## Examples
 


### PR DESCRIPTION
Hi, thanks for making this

I found a couple of repeated typos and abbreviations in the docs. I did a quick search and replace to clean them up.

I hope this is helpful :)