### PR TITLE
Add user agent

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        meili: [1.0.2, 1.1.1]
+        meili: [1.0.2, 1.1.1, 1.2.0]
 
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM elixir:1.14.4-alpine
+
+RUN apk add bash curl && \
+    mix local.hex --force && \
+    mix local.rebar --force
+
+ENV APP_HOME /package
+
+WORKDIR $APP_HOME

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,0 @@
-FROM elixir:1.14.4-alpine
-
-RUN apk add bash curl && \
-    mix local.hex --force && \
-    mix local.rebar --force
-
-ENV APP_HOME /package
-
-WORKDIR $APP_HOME

--- a/lib/meilisearch.ex
+++ b/lib/meilisearch.ex
@@ -1,6 +1,4 @@
 defmodule Meilisearch do
-  @version "1.1.0"
-
   @moduledoc """
   A client for [MeiliSearch](https://meilisearch.com).
   The following Modules are provided for interacting with Meilisearch:
@@ -113,5 +111,5 @@ defmodule Meilisearch do
     GenServer.call(to_name(name), :client)
   end
 
-  def qualified_version, do: "Meilisearch Elixir (v#{@version})"
+  def qualified_version, do: "Meilisearch Elixir (v#{Application.spec(:meilisearch_ex)[:vsn]})"
 end

--- a/lib/meilisearch.ex
+++ b/lib/meilisearch.ex
@@ -1,4 +1,6 @@
 defmodule Meilisearch do
+  @version "1.1.0"
+
   @moduledoc """
   A client for [MeiliSearch](https://meilisearch.com).
   The following Modules are provided for interacting with Meilisearch:
@@ -110,4 +112,6 @@ defmodule Meilisearch do
   def client(name) do
     GenServer.call(to_name(name), :client)
   end
+
+  def qualified_version, do: "Meilisearch Elixir (v#{@version})"
 end

--- a/lib/meilisearch/client.ex
+++ b/lib/meilisearch/client.ex
@@ -33,7 +33,8 @@ defmodule Meilisearch.Client do
       Tesla.Middleware.JSON,
       Tesla.Middleware.PathParams,
       {Tesla.Middleware.BearerAuth, token: key},
-      {Tesla.Middleware.Headers, [{"Content-Type", "application/json"}]},
+      {Tesla.Middleware.Headers,
+       [{"Content-Type", "application/json"}, {"User-Agent", Meilisearch.qualified_version()}]},
       {Tesla.Middleware.Timeout, timeout: timeout},
       {Tesla.Middleware.Logger,
        log_level: log_level, debug: debug, filter_headers: ["authorization"]}


### PR DESCRIPTION
Following this issue: https://github.com/meilisearch/integration-guides/issues/150

We use this data internally to understand the users' behavior better, whether they are using our SDKs or not, and then prioritize it based on the data.

So, in this PR, I'm adding this configuration. 

This is working: `test-meilisearch-1  | [2023-06-30T18:02:24Z INFO  actix_web::middleware::logger] 172.18.0.4 "POST /indexes/ingredients/documents HTTP/1.1" 202 139 "-" "Meilisearch Elixir (v1.1.0)" 0.003105`

If this implementation could be better, let me know!