### PR TITLE
feat: allow another Tesla adapter for HTTP calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,30 @@ defmodule MyApp.MyContext do
 end
 ```
 
+### Using another HTTP adapter
+
+Given that the HTTP client is backed by Tesla behind the scene, you can freely use another adapter if it is more suitable for you.
+
+```elixir
+def deps do
+  [
+    {:hackney, "~> 1.18"},
+    {:meilisearch_ex, "~> 1.1.1"}
+  ]
+end
+```
+```elixir
+
+# Create a Meilisearch client whenever and wherever you need it.
+[endpoint: "http://127.0.0.1:7700", key: "masterKey", adapter: Tesla.Adapter.Hackney]
+|> Meilisearch.Client.new()
+|> Meilisearch.Health.get()
+
+# %Meilisearch.Health{status: "available"}
+```
+
+
+
 ## 🎬 Getting started
 
 ### Add documents <!-- omit in toc -->

--- a/lib/meilisearch/client.ex
+++ b/lib/meilisearch/client.ex
@@ -27,6 +27,7 @@ defmodule Meilisearch.Client do
     log_level = Keyword.get(opts, :log_level, :warn)
     debug = Keyword.get(opts, :debug, false)
     finch = Keyword.get(opts, :finch)
+    tesla_adapter = Keyword.get(opts, :adapter, Tesla.Adapter.Finch)
 
     middleware = [
       {Tesla.Middleware.BaseUrl, endpoint},
@@ -40,7 +41,7 @@ defmodule Meilisearch.Client do
        log_level: log_level, debug: debug, filter_headers: ["authorization"]}
     ]
 
-    adapter = {Tesla.Adapter.Finch, name: finch, receive_timeout: 30_000}
+    adapter = {tesla_adapter, name: finch, receive_timeout: 30_000}
 
     Tesla.client(middleware, adapter)
   end


### PR DESCRIPTION
This PR offers the opportunity to use another HTTP client instead of Finch.