### PR TITLE
fix(client): keep tesla default log level

### DIFF
--- a/lib/meilisearch/client.ex
+++ b/lib/meilisearch/client.ex
@@ -24,7 +24,7 @@ defmodule Meilisearch.Client do
     endpoint = Keyword.get(opts, :endpoint, "")
     key = Keyword.get(opts, :key, "")
     timeout = Keyword.get(opts, :timeout, 2_000)
-    log_level = Keyword.get(opts, :log_level, :warn)
+    log_level = Keyword.get(opts, :log_level, nil)
     debug = Keyword.get(opts, :debug, false)
     finch = Keyword.get(opts, :finch)
     tesla_adapter = Keyword.get(opts, :adapter, Tesla.Adapter.Finch)


### PR DESCRIPTION
We'd like to keep tesla default log level if not provided to avoid every log to be qualified as `warning`, would you agree?

In the meantime, we were able to mitigate this by giving `fn _ -> :default end` to `log_level` opt