### PR TITLE
fix: add missing case in spec of multi_search

### DIFF
--- a/lib/meilisearch/multi_search.ex
+++ b/lib/meilisearch/multi_search.ex
@@ -127,6 +127,7 @@ defmodule Meilisearch.MultiSearch do
         ) ::
           {:ok, __MODULE__.t(Meilisearch.Document.t())}
           | {:error, Meilisearch.Client.error()}
+          | {:error, Meilisearch.Client.error(), non_neg_integer()}
   def multi_search(client, params \\ %{})
 
   def multi_search(client, params) when is_list(params),


### PR DESCRIPTION
`Meilisearch.MultiSearch.multi_search` calls `Meilisearch.Client.handle_response()` ([here](https://github.com/nutshell-lab/meilisearch-ex/blob/f2d8d9bd3086465d19cb402d4d0958db9fb6832d/lib/meilisearch/multi_search.ex#L148)) which can return `{:error, Meilisearch.Error.cast(body), status}` ([here](https://github.com/nutshell-lab/meilisearch-ex/blob/f2d8d9bd3086465d19cb402d4d0958db9fb6832d/lib/meilisearch/client.ex#L58))

Because this case is missing in `multi_search` spec ([here](https://github.com/nutshell-lab/meilisearch-ex/blob/f2d8d9bd3086465d19cb402d4d0958db9fb6832d/lib/meilisearch/multi_search.ex#L124-L129)), dialyxir returns this error when `multi_search` fun is used:

```
The pattern can never match the type.

Pattern:
{:error, _error, _status}

Type:

  {:error,
   Tesla.Error
   | nil
   | %Meilisearch.Error{
       :code => atom(),
       :link => binary(),
       :message => binary(),
       :type => :auth | :internal | :invalid_request | :system
     }}
```

