### PR TITLE
Use :name in child spec as child id

### DIFF
--- a/lib/meilisearch.ex
+++ b/lib/meilisearch.ex
@@ -78,7 +78,16 @@ defmodule Meilisearch do
 
   use GenServer
 
-  defp to_name(name), do: :"__MODULE__:#{name}"
+  def child_spec(opts) do
+    name = Keyword.fetch!(opts, :name)
+
+    %{
+      id: name,
+      start: {__MODULE__, :start_link, [opts]}
+    }
+  end
+
+  defp to_name(name), do: :"#{inspect(__MODULE__)}:#{name}"
 
   @spec start_link(atom(),
           endpoint: String.t(),


### PR DESCRIPTION
This is similar to https://github.com/sneako/finch/commit/6b42c8eec2c3df04cde5b550c6a3960e176949f0

While at it I made the following change which fixes what I think was unintentional ommision of interpolation:

    -  defp to_name(name), do: :"__MODULE__:#{name}"
    +  defp to_name(name), do: :"#{inspect(__MODULE__)}:#{name}"

I also noticed we have:

    def start_link(opts) when is_list(opts) do
      with {:ok, name} <- Keyword.fetch(opts, :name) do
        GenServer.start_link(__MODULE__, opts, name: to_name(name))
      end
    end

And so if we do this, i.e. don't pass :name, we'll get :error

    iex> Meilisearch.start_link([])
    :error

That is not a common return value from start_link. Supervisor will crash on it. So while the `child_spec/1` change that I am proposing is technically a breaking change I think it is warranted as the current behaviour under that circumstance, not passing name, was also crashing.

In this spirit, my suggestion is to change start_link, something like:

       def start_link(opts) when is_list(opts) do
    -    with {:ok, name} <- Keyword.fetch(opts, :name) do
    -      GenServer.start_link(__MODULE__, opts, name: to_name(name))
    -    end
    +    name = Keyword.fetch!(opts, :name)
    +    GenServer.start_link(__MODULE__, opts, name: to_name(name))
       end

Which I'm happy to do. let me know!
