### PR TITLE
COL-8508 - FunctionClauseError: no function clause matching in Meilisearch.Error.cast/1

### DIFF
--- a/lib/meilisearch/error.ex
+++ b/lib/meilisearch/error.ex
@@ -132,13 +132,11 @@ defmodule Meilisearch.Error do
     )
   end
 
-  def cast(data) when is_nil(data), do: nil
-
-  def cast(""), do: nil
-
   def cast(data) when is_map(data) do
     %__MODULE__{}
     |> Ecto.Changeset.cast(data, [:message, :link, :type, :code])
     |> Ecto.Changeset.apply_changes()
   end
+
+  def cast(_), do: nil
 end

--- a/lib/meilisearch/error.ex
+++ b/lib/meilisearch/error.ex
@@ -134,6 +134,8 @@ defmodule Meilisearch.Error do
 
   def cast(data) when is_nil(data), do: nil
 
+  def cast(""), do: nil
+
   def cast(data) when is_map(data) do
     %__MODULE__{}
     |> Ecto.Changeset.cast(data, [:message, :link, :type, :code])


### PR DESCRIPTION
```
FunctionClauseError: no function clause matching in Meilisearch.Error.cast/1
  File "lib/meilisearch/error.ex", line 135, in Meilisearch.Error.cast/1
  File "lib/meilisearch/client.ex", line 58, in Meilisearch.Client.handle_response/1
  File "lib/meilisearch/search.ex", line 148, in Meilisearch.Search.search/3
```