### PR TITLE
Remove ducpicate application/json header

### DIFF
--- a/lib/meilisearch/client.ex
+++ b/lib/meilisearch/client.ex
@@ -35,7 +35,7 @@ defmodule Meilisearch.Client do
       Tesla.Middleware.PathParams,
       {Tesla.Middleware.BearerAuth, token: key},
       {Tesla.Middleware.Headers,
-       [{"Content-Type", "application/json"}, {"User-Agent", Meilisearch.qualified_version()}]},
+       [{"User-Agent", Meilisearch.qualified_version()}]},
       {Tesla.Middleware.Timeout, timeout: timeout},
       {Tesla.Middleware.Logger,
        log_level: log_level, debug: debug, filter_headers: ["authorization"]}

--- a/lib/meilisearch/client.ex
+++ b/lib/meilisearch/client.ex
@@ -34,20 +34,7 @@ defmodule Meilisearch.Client do
       Tesla.Middleware.JSON,
       Tesla.Middleware.PathParams,
       {Tesla.Middleware.BearerAuth, token: key},
-      {Tesla.Middleware.Headers, fn %{headers: headers} ->
-        user_agent_header = {"User-Agent", Meilisearch.qualified_version()}
-
-        headers = headers || []
-        content_type_exists = Enum.any?(headers, fn {header, value} ->
-          String.downcase(header) == "content-type" && String.contains?(String.downcase(value), "application/json")
-        end)
-
-        if content_type_exists do
-          [user_agent_header]
-        else
-          [user_agent_header, {"Content-Type", "application/json"}]
-        end
-      end},
+      Meilisearch.Middleware.Headers,
       {Tesla.Middleware.Timeout, timeout: timeout},
       {Tesla.Middleware.Logger,
        log_level: log_level, debug: debug, filter_headers: ["authorization"]}

--- a/lib/meilisearch/middleware/headers.ex
+++ b/lib/meilisearch/middleware/headers.ex
@@ -1,0 +1,30 @@
+defmodule Meilisearch.Middleware.Headers do
+  @moduledoc """
+  Middleware for dealing with Meilisearch request headers.
+  Ensures there is exactly one Content-Type: application/json header
+  and adds the User-Agent header.
+  """
+  @behaviour Tesla.Middleware
+
+  @impl Tesla.Middleware
+  def call(env, next, _options) do
+    env
+    |> Tesla.put_header("user-agent", Meilisearch.qualified_version())
+    |> ensure_single_content_type()
+    |> Tesla.run(next)
+  end
+
+  # Ensure there is exactly one Content-Type: application/json header
+  defp ensure_single_content_type(%Tesla.Env{headers: headers} = env) do
+    # Filter out all headers that are not content-type
+    filtered_headers = Enum.filter(headers, fn {header, _value} -> 
+      String.downcase(header) != "content-type"
+    end)
+    
+    # Create a new environment with only non-content-type headers
+    env = %{env | headers: filtered_headers}
+    
+    # Add a single content-type header
+    Tesla.put_header(env, "content-type", "application/json")
+  end
+end


### PR DESCRIPTION
`Tesla.Middleware.JSON` already includes the `{"Content-Type", "application/json"}` header. 

Duplicate headers may trigger a search error.